### PR TITLE
fix typo in browser.js

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -35,7 +35,7 @@ module.exports = function(url, opts) {
     if (destroyed) return
     destroyed = true
     es.close()
-    parse.emit('close')
+    rs.emit('close')
   }
 
   return rs


### PR DESCRIPTION
Was playing with getting `friends` working in the browser (https://github.com/moose-team/friends/issues/112)  and ran across an error in the console:

```
Uncaught ReferenceError: parse is not defined
```

This looks to be the culprit! :)
