### PR TITLE
Setup tests to run in a server/browser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - "0.10"
-
 script: "npm test"
+before_script:
+  - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,3 +1,0 @@
-ui: tape
-server:
-  cmd: ./test-server.js

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,0 +1,3 @@
+ui: tape
+server:
+  cmd: ./test-server.js

--- a/browser.js
+++ b/browser.js
@@ -2,8 +2,9 @@ var stream = require('stream')
 
 module.exports = function(url, opts) {
   if (!opts) opts = {}
-
-  var es = new EventSource(url)
+  var es = new EventSource(url, {
+    withCredentials: opts.withCredentials === true
+  })
   var rs = new stream.Readable({objectMode:true})
 
   var json = !!opts.json

--- a/package.json
+++ b/package.json
@@ -9,12 +9,13 @@
     "split2": "^0.1.2"
   },
   "devDependencies": {
+    "browserify": "^11.0.0",
+    "electron-prebuilt": "^0.30.0",
     "tape": "^2.13.3",
-    "zuul": "^3.2.0"
+    "testron": "^1.2.0"
   },
   "scripts": {
-    "test": "tape test-server.js",
-    "test-browser": "zuul --ui tape --local 9966 -- test.js"
+    "test": "node test-server.js & browserify test.js | testron && kill $!"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
     "split2": "^0.1.2"
   },
   "devDependencies": {
-    "tape": "^2.13.3"
+    "tape": "^2.13.3",
+    "zuul": "^3.2.0"
   },
   "scripts": {
-    "test": "tape test.js"
+    "test": "tape test-server.js",
+    "test-browser": "zuul --ui tape --local 9966 -- test.js"
   },
   "repository": {
     "type": "git",

--- a/test-server.js
+++ b/test-server.js
@@ -1,0 +1,29 @@
+var http = require('http')
+
+var port = process.env['ZUUL_PORT'] || 0
+
+var server = http.createServer(function(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', 'http://localhost:9966')
+  res.setHeader('Access-Control-Expose-Headers', '*')
+  res.setHeader('Access-Control-Allow-Credentials', true)
+  res.setHeader('Content-Type', 'text/event-stream')
+  if (req.url === '/multiline') {
+    res.write('data: a\n')
+    res.write('data: b\n\n')
+  }
+  if (req.url === '/basic') {
+    res.write('data: hello world\n\n')
+  }
+  if (req.url === '/crash') {
+    res.write('data: test\n\n')
+    res.end()
+  }
+})
+
+server.listen(port, function() {
+  // If we're not running through zuul, just run the tests
+  if (!process.env['ZUUL_PORT']) {
+    server.unref()
+    require('./test.js')(server.address().port)
+  }
+})

--- a/test-server.js
+++ b/test-server.js
@@ -1,9 +1,9 @@
 var http = require('http')
 
-var port = process.env['ZUUL_PORT'] || 0
+var port = process.env['PORT'] || 9966
 
 var server = http.createServer(function(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', 'http://localhost:9966')
+  res.setHeader('Access-Control-Allow-Origin', 'http://localhost:'+port)
   res.setHeader('Access-Control-Expose-Headers', '*')
   res.setHeader('Access-Control-Allow-Credentials', true)
   res.setHeader('Content-Type', 'text/event-stream')
@@ -20,10 +20,6 @@ var server = http.createServer(function(req, res) {
   }
 })
 
-server.listen(port, function() {
-  // If we're not running through zuul, just run the tests
-  if (!process.env['ZUUL_PORT']) {
-    server.unref()
-    require('./test.js')(server.address().port)
-  }
+server.listen(port, function () {
+  require('./test.js')
 })

--- a/test.js
+++ b/test.js
@@ -1,55 +1,50 @@
+process.browser = true
 var tape = require('tape')
 var ess = require('./')
 
-var runTests = module.exports = function (port) {
-  var addr = 'http://localhost:'+port
-  var opts = {withCredentials:true}
+var port = process.env['PORT'] || 9966
+var addr = 'http://localhost:'+port
+var opts = {withCredentials:true}
 
-  tape('open', function (t) {
-    var stream = ess(addr+'/basic', opts)
+tape('open', function (t) {
+  var stream = ess(addr+'/basic', opts)
 
-    stream.on('open', function () {
+  stream.on('open', function () {
+    stream.destroy()
+    t.ok(true, 'open has been called')
+    t.end()
+  })
+})
+
+tape('events', function(t) {
+  var stream = ess(addr+'/basic', opts)
+
+  stream.on('data', function(data) {
+    stream.destroy()
+    t.same(data, 'hello world')
+    t.end()
+  })
+})
+
+tape('multiline events', function(t) {
+  var stream = ess(addr+'/multiline', opts)
+
+  stream.on('data', function(data) {
+    stream.destroy()
+    t.same(data, 'a\nb')
+    t.end()
+  })
+})
+
+tape('retry', function(t) {
+  var stream = ess(addr+'/crash', {retry:100,withCredentials:true})
+  var cnt = 2
+
+  stream.on('data', function(data) {
+    if (!--cnt) {
       stream.destroy()
-      t.ok(true, 'open has been called')
       t.end()
-    })
+    }
+    t.same(data, 'test')
   })
-
-  tape('events', function(t) {
-    var stream = ess(addr+'/basic', opts)
-
-    stream.on('data', function(data) {
-      stream.destroy()
-      t.same(data, 'hello world')
-      t.end()
-    })
-  })
-
-  tape('multiline events', function(t) {
-    var stream = ess(addr+'/multiline', opts)
-
-    stream.on('data', function(data) {
-      stream.destroy()
-      t.same(data, 'a\nb')
-      t.end()
-    })
-  })
-
-  tape('retry', function(t) {
-    var stream = ess(addr+'/crash', {retry:100,withCredentials:true})
-    var cnt = 2
-
-    stream.on('data', function(data) {
-      if (!--cnt) {
-        stream.destroy()
-        t.end()
-      }
-      t.same(data, 'test')
-    })
-  })
-}
-
-// If were running tests in the browser, run them with the zuul port
-if (process.browser) {
-  runTests(window.ZUUL.port)
-}
+})


### PR DESCRIPTION
Hey! I was investigating an error on `webrtc-swarm`: https://github.com/mafintosh/webrtc-swarm/issues/2 where `open` doesn't get emitted in a browser. This appeared to happen because of 2 reasons:
- `event-source-stream` didn't emit `open` with `es.onopen = function () {}` but for some reason does when using `es.addEventListener('open', function () {})`
- `signalhub` doesn't bubble the `open` event that happens on an individual stream to the `all` stream. So `webrtc-swarm` doesn't get the event, even when actually emitted.

~~In hunting down this issue I was testing in the browser using [zuul](https://www.npmjs.com/package/zuul). I'm not sure if you want to use zuul or not but I find it to be pretty good at testing both server/client and opening this PR for your consideration.~~

This PR:
- ~~`npm test` still starts up the server and runs the server tests.~~
- ~~`npm run test-browser` starts the server and makes the tests runnable in a browser at http://locahost:9966/__zuul~~
- Adds the `withCredentials` option for enabling CORS with `EventSource` in the browser
- Has the tests run in a browser using [testron](https://www.npmjs.com/package/testron)

In testing this, it appears `es.onopen` does in fact work. So I'm still looking into why it doesn't work in tandem with `webrtc-swarm`.

Thanks!
