### PR TITLE
Use browser implementation of Node.js' stream library

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,4 +1,4 @@
-var stream = require('stream')
+var stream = require('readable-stream')
 
 module.exports = function(url, opts) {
   if (!opts) opts = {}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "once": "^1.3.1",
+    "readable-stream": "^2.2.2",
     "request": "^2.36.0",
     "split2": "^0.1.2"
   },


### PR DESCRIPTION
Use https://github.com/nodejs/readable-stream instead of the native `stream` lib. This makes it work on client side.